### PR TITLE
Fix insert and delete to make sure they are inverses of each other

### DIFF
--- a/src/main/java/edu/usc/pgroup/louvain/hadoop/Community.java
+++ b/src/main/java/edu/usc/pgroup/louvain/hadoop/Community.java
@@ -108,7 +108,7 @@ public class Community {
         assert(node >= 0 && node < size);
 
         tot.set(comm,tot.get(comm)-g.weighted_degree(node) - g.weighted_degree_wremote(node));
-        in.set(comm, in.get(comm) - 2 * dnodecomm + g.nb_selfloops(node));
+        in.set(comm, in.get(comm) - (2 * dnodecomm + g.nb_selfloops(node)));
         n2c.set(node,-1);
 
     }
@@ -118,7 +118,7 @@ public class Community {
         assert(node >= 0 && node < size);
 
         tot.set(comm,tot.get(comm) + g.weighted_degree(node) + g.weighted_degree_wremote(node));
-        in.set(comm, in.get(comm) +  2 * dnodecomm + g.nb_selfloops(node));
+        in.set(comm, in.get(comm) +  (2 * dnodecomm + g.nb_selfloops(node)));
         n2c.set(node,comm);
 
     }


### PR DESCRIPTION
When copying from the baseline BGLL code, a set of parentheses was forgotten, causing the number of self-loops to be added in all cases, instead of added on insert and subtracted on remove
