### PR TITLE
Update source of remote links when combining nodes into one community

### DIFF
--- a/src/main/java/edu/usc/pgroup/louvain/hadoop/Community.java
+++ b/src/main/java/edu/usc/pgroup/louvain/hadoop/Community.java
@@ -368,7 +368,15 @@ public class Community {
 
 
         }
-        g2.setRemoteMaps(g.getRemoteMaps());
+
+        // Update sources in the remote maps lists to the new numbering
+        Vector<RemoteMap> oldRemoteMaps = g.getRemoteMaps();
+        Vector<RemoteMap> newRemoteMaps = new Vector<RemoteMap>();
+        for (RemoteMap oldMap: oldRemoteMaps.getList()) {
+            newRemoteMaps.getList().add(new RemoteMap(renumber.get(n2c.get(oldMap.source)), oldMap.getSink(), oldMap.getSinkPart()));
+        }
+
+        g2.setRemoteMaps(newRemoteMaps);
         return g2;
     }
 


### PR DESCRIPTION
When reducing a graph (via Community.partition2graph_binary), update  the sources in the list of RemoteMaps to be the new sources - they aren't updated on the combining end.

I've written a test case to show this is needed, but I can't really check it in - testing involves some changes to Community to allow it to run (not randomizing node order, so test is repeatable, and eliminating some of the hadoop structure)

I'm pretty sure this is an error in the C version too, but I'm not set up to test that.
