### PR TITLE
Revert improvement check in one_level to baseline BGLL version

### DIFF
--- a/src/main/java/edu/usc/pgroup/louvain/hadoop/Community.java
+++ b/src/main/java/edu/usc/pgroup/louvain/hadoop/Community.java
@@ -448,7 +448,7 @@ public class Community {
             if (nb_moves > 0)
                 improvement = true;
 
-        } while (nb_moves > 0 && Math.abs(new_mod - cur_mod) > min_modularity);
+        } while (nb_moves > 0 && (new_mod - cur_mod) > min_modularity);
 
         return improvement;
     }


### PR DESCRIPTION
The parallelization code changed one_level to continue on sufficient increase or decrease in modularity, rather than just sufficient increase, as the original BGLL louvain algorithm specified.  I believe the original is correct.

If this change was deliberate and useful, a comment as to why would be very helpful - from my reading, the insertion of the abs() function just means the algorithm will keep reducing the graph happily if it's making things worse, not just better, as long as it is making it enough worse.

I believe this is not a bug in the C code too, I'm not sure why it was changed for the map/reduce version.
